### PR TITLE
Increase usefulness of data-autofill

### DIFF
--- a/src/datalist-ajax.js
+++ b/src/datalist-ajax.js
@@ -111,7 +111,7 @@ class AutoComplete extends HTMLElement {
       let reset = {};
       for (const name in data) {
 
-        Array.from(this.input.form.querySelectorAll(`[data-autofill="${ name }"]`)).forEach(f => {
+        Array.from(this.input.form.querySelectorAll(`[data-autofill="${name}"]:not([data-autofill-source]), [data-autofill="${name}"][data-autofill-source="${(this.input.name || this.input.id)}"]`)).forEach(f => {
           f.value = data[name] || '';
           reset[name] = '';
         });


### PR DESCRIPTION
This change increases the usefulness of the ```data-autofill``` attribute by allowing for an additional optional attribute, ```data-autofill-source```, to further refine the querySelector filter used to autofill values on change.

Resolves #1 